### PR TITLE
Additional settings and compability modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-# carrotwaxr's Stash Plugins
+# Modified carrotwaxr's mcMetadata plugin
 
-This repository holds plugins for extending the functionality of [Stash](https://github.com/stashapp/stash) adult media manager.
+This repository holds modified version of mcMetadata by carrotwaxr for extending the functionality of [Stash](https://github.com/stashapp/stash) adult media manager.
+
+Modification made to increase compability and interobility between mcMetadata, nfSceneParser (other stash plugin) Jellyfin.Plugin.Stash.
+
+I didn't create pull request to the original repository and created fork instead because some modifications felt arbitrary, tailored to my specific needs and could break other people's workflows (eg. removal of stashId requirement or custom_tags field).
+
+## What was added or changed:
+
+- added hook on performer update that extracts new image, so you don't have to run it manually or update scene
+- added possibility to change batch size (there is an unknown bug when batch size is bigger than 1)
+- removed requirement for scene to have stashId
+- added posibility to change the name of generated nfo file, so now it can be movie.nfo which can be automatically updated by Jellyfin
+- added posibility to change the name of generated poster image, so now you can name it folder.jpg and Jellyfin won't generate additional file
+- added posibility to generate backdrop.jpg which can be read by Jellyfin
+- added posibility to modify which rating field to use so you can export your ratings into "rating" field instead of "userrating", which can be read and correctly displayed by Jellyfin.
+- added exporting of director for scene
+- removed custom_rating field
+- added posibility to change default genere for scenes

--- a/plugins/mcMetadata/mcMetadata.py
+++ b/plugins/mcMetadata/mcMetadata.py
@@ -4,7 +4,7 @@ import sqlite3
 import sys
 import stashapi.log as log
 from stashapi.stashapp import StashInterface
-from performer import process_all_performers
+from performer import process_all_performers, process_performer
 from scene import process_all_scenes, process_scene
 from utils.settings import read_settings, update_setting
 
@@ -88,10 +88,19 @@ match mode:
 
         scene_id = PLUGIN_ARGS["hookContext"]["id"]
         scene = stash.find_scene(scene_id)
-        stash_ids = scene["stash_ids"]
-        if stash_ids is not None and len(stash_ids) > 0:
+        if scene is not None and scene['organized'] is True:
             log.info("Running scene updater")
             process_scene(scene, stash, SETTINGS, cursor, api_key)
+    case "Performer.Update.Post":
+        if not SETTINGS["enable_hook"]:
+            log.debug("Hook disabled")
+            sys.exit(0)
+        
+        performer_id = PLUGIN_ARGS["hookContext"]["id"]
+        performer = stash.find_performer(performer_id)
+        if performer is not None:
+            log.info("Running performer updater")
+            process_performer(performer, SETTINGS, api_key, True)
 
 
 # commit db changes & cleanup

--- a/plugins/mcMetadata/mcMetadata.yml
+++ b/plugins/mcMetadata/mcMetadata.yml
@@ -4,35 +4,36 @@ url: https://github.com/carrotwaxr/stash-plugins/tree/main/mcMetadata
 version: 0.0.3
 exec:
   - python
-  - "{pluginDir}/mcMetadata.py"
+  - '{pluginDir}/mcMetadata.py'
 interface: raw
 hooks:
   - name: hook_mcmetadata
     description: Organize/rename video files and create/update metadata files when you update a scene.
     triggeredBy:
       - Scene.Update.Post
+      - Performer.Update.Post
 tasks:
-  - name: "Disable"
+  - name: 'Disable'
     description: Disable the on Scene Update hook
     defaultArgs:
       mode: disable
-  - name: "Enable"
+  - name: 'Enable'
     description: Enable the on Scene Update hook
     defaultArgs:
       mode: enable
-  - name: "Toggle Dry Run"
+  - name: 'Toggle Dry Run'
     description: Enable/disable dry-run mode
     defaultArgs:
       mode: dryrun
-  - name: "Toggle Renamer"
+  - name: 'Toggle Renamer'
     description: Enable/disable file renaming
     defaultArgs:
       mode: renamer
-  - name: "Bulk Update"
+  - name: 'Bulk Update'
     description: Organize/rename video files and create/update metadata files for all scenes based on your config.
     defaultArgs:
       mode: bulk
-  - name: "Bulk Update Performers"
+  - name: 'Bulk Update Performers'
     description: Copy all performer images to your chosen Media Center's people folder.
     defaultArgs:
       mode: performers

--- a/plugins/mcMetadata/performer.py
+++ b/plugins/mcMetadata/performer.py
@@ -2,11 +2,10 @@ import os
 import stashapi.log as log
 from utils.files import download_image
 
-# Constants
-BATCH_SIZE = 100
-
 
 def process_all_performers(stash, settings, api_key):
+    BATCH_SIZE = int(settings["batch_size"])
+
     count = stash.find_performers(
         f={},
         filter={"per_page": 1},

--- a/plugins/mcMetadata/settings_example.ini
+++ b/plugins/mcMetadata/settings_example.ini
@@ -10,14 +10,20 @@
 #   Mac OS: 255 (filename), maximum total path 1024
 
 [settings]
-dry_run = true
+dry_run = false
 enable_hook = true
 enable_renamer = true
-renamer_path = /data/tagged/
+renamer_path = /data/videos/organized/
 renamer_ignore_files_in_path = false
-renamer_enable_mark_organized = true
+renamer_enable_mark_organized = false
 renamer_filename_budget = 250
-renamer_path_template = $Studio/$Title - $FemalePerformers $MalePerformers $ReleaseDate [WEBDL-$Resolution]
+renamer_path_template = $Studio/$Title ($ReleaseDate)/$Title ($ReleaseDate)
 media_server = jellyfin
 enable_actor_images = true
-actor_metadata_path = /jellyfin/data/metadata/People/
+actor_metadata_path = /jellyfin/metadata/People/
+batch_size = 1
+custom_nfo_name = movie.nfo
+custom_poster_name = folder.jpg
+extract_backdrop = true
+default_rating = rating
+genre = Adult

--- a/plugins/mcMetadata/utils/nfo.py
+++ b/plugins/mcMetadata/utils/nfo.py
@@ -3,25 +3,26 @@ import os
 INDENTED_NEWLINE = "\n    "
 
 
-def build_nfo_xml(scene):
+def build_nfo_xml(scene, settings):
     ret = """<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <movie>
     <name>{title}</name>
     <title>{title}</title>
     <originaltitle>{title}</originaltitle>
     <sorttitle>{title}</sorttitle>
-    <criticrating>{custom_rating}</criticrating>
-    <rating>{rating}</rating>
-    <userrating>{rating}</userrating>
+    <director>{director}</director>
+    <{default_rating}>{rating}</{default_rating}>
     <plot><![CDATA[{details}]]></plot>
     <premiered>{date}</premiered>
     <releasedate>{date}</releasedate>
     <year>{year}</year>
     <studio>{studio}</studio>{performers}
-    <genre>Adult</genre>{tags}
+    <genre>{genre}</genre>{tags}
     <uniqueid type="stash">{id}</uniqueid>
 </movie>"""
 
+    default_rating = settings.get("default_rating", "userrating")
+    genre = settings.get("genre", "Adult")
     id = scene["id"]
     details = scene["details"] or ""
 
@@ -31,11 +32,9 @@ def build_nfo_xml(scene):
     else:
         title = os.path.basename(os.path.normpath(scene["files"][0]["path"]))
 
-    custom_rating = ""
     rating = ""
     if scene["rating100"] is not None:
         rating = round(int(scene["rating100"]) / 10)
-        custom_rating = scene["rating100"]
 
     date = ""
     year = ""
@@ -46,6 +45,10 @@ def build_nfo_xml(scene):
     studio = ""
     if scene["studio"] is not None:
         studio = scene["studio"]["name"]
+    
+    director = ""
+    if scene["director"] is not None:
+        director = scene["director"]
 
     performers = INDENTED_NEWLINE
     i = 0
@@ -78,8 +81,10 @@ def build_nfo_xml(scene):
 
     return ret.format(
         title=title,
-        custom_rating=custom_rating,
+        director=director,
+        default_rating=default_rating,
         rating=rating,
+        genre=genre,
         id=id,
         tags=tags,
         date=date,

--- a/plugins/mcMetadata/utils/settings.py
+++ b/plugins/mcMetadata/utils/settings.py
@@ -22,6 +22,7 @@ SETTINGS_BOOLEANS = [
     "enable_renamer",
     "renamer_ignore_files_in_path",
     "renamer_enable_mark_organized",
+    "extract_backdrop"
 ]
 VALID_MEDIA_SERVERS = ["emby", "jellyfin"]
 


### PR DESCRIPTION
What was added or change:
- added hook on performer update that extracts new image, so you don't have to run it manually or update scene
- added possibility to change batch size (there is an unknown bug when batch size is bigger than 1)
- removed requirement for scene to have stashId
- added posibility to change the name of generated nfo file, so now it can be movie.nfo which can be automatically updated by Jellyfin
- added posibility to change the name of generated poster image, so now you can name it folder.jpg and Jellyfin won't generate additional file
- added posibility to generate backdrop.jpg which can be read by Jellyfin
- added posibility to modify which rating field to use so you can export your ratings into "rating" field instead of "userrating", which can be read and correctly displayed by Jellyfin.
- added exporting of director for scene
- removed custom_rating field
- added posibility to change default genere for scenes